### PR TITLE
Use wrap safe ops in `bloom_hash`

### DIFF
--- a/src/bloomfilter/lib.rs
+++ b/src/bloomfilter/lib.rs
@@ -134,7 +134,7 @@ impl Bloom {
             hashes[k_i as usize] = hash;
             hash
         } else {
-            hashes[0] + (((k_i as u64) * hashes[1]) % 0xffffffffffffffc5)
+            hashes[0].wrapping_add((k_i as u64).wrapping_mul(hashes[1]) % 0xffffffffffffffc5)
         }
     }
 


### PR DESCRIPTION
I had overflows when running tests. I haven't brushed up on the details of the bloom filter implementation. So assuming that overflows are expected, this PR uses ops that permit wrapping without panicing in debug mode.