### PR TITLE
Store and load state of bloomfilter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ path = "src/bloomfilter/lib.rs"
 [dependencies]
 bit-vec = "~0.4"
 rand = "~0.3"
-siphasher = "~0.2"
+siphasher = "^0.2.2"


### PR DESCRIPTION
We have a use case where we want the bloomfilter to survive a restart, this pull adds a way to extract and load back the filter's state.

I've removed the random keys to the sip hasher to make this work. What is the added value of using a random key? If this is a necessary part of operations I could also store the keys so they can be retrieved too.