### PR TITLE
Split bloom state and configuration into separate structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bloomfilter"
-version = "0.0.12"
+version = "0.1.0"
 authors = ["Frank Denis <github@pureftpd.org>"]
 description = "Bloom filter implementation"
 license = "ISC"

--- a/src/bloomfilter/lib.rs
+++ b/src/bloomfilter/lib.rs
@@ -46,7 +46,6 @@ pub struct BloomState {
 }
 
 /// The configuration used to create a Bloom filter
-#[derive(Clone)]
 pub struct BloomHasher<T: Hash> {
     bitmap_bits: u64,
     k_num: u32,
@@ -253,6 +252,13 @@ impl<T: Hash> BloomHasher<T> {
 
     fn sip_keys(&self) -> [(u64, u64); 2] {
         [self.sips[0].keys(), self.sips[1].keys()]
+    }
+}
+
+impl<T: Hash> Clone for BloomHasher<T> {
+    fn clone(&self) -> Self {
+        BloomHasher::new(self.bitmap_bits, self.k_num, self.sips.clone())
+        // bitmap_bits: u64, k_num: u32, sips: [SipHasher13;2]
     }
 }
 

--- a/src/bloomfilter/lib.rs
+++ b/src/bloomfilter/lib.rs
@@ -84,7 +84,7 @@ impl<T: Hash> Bloom<T> {
 
     /// Create a bloom filter structure with an existing state.
     ///
-    /// `state` is assumed to be retrieved from an existing bloom filter.
+    /// state is assumed to be retrieved from an existing bloom filter.
     pub fn from_existing(
         bitmap: &[u8],
         bitmap_bits: u64,

--- a/src/bloomfilter/lib.rs
+++ b/src/bloomfilter/lib.rs
@@ -140,10 +140,7 @@ impl<T: Hash> Bloom<T> {
     }
 
     /// Record the presence of an item.
-    pub fn set(&mut self, item: &T)
-    where
-        T: Hash,
-    {
+    pub fn set(&mut self, item: &T) {
         let offsets = self.make_offsets(item);
         self.set_offsets(&offsets);
     }
@@ -158,10 +155,7 @@ impl<T: Hash> Bloom<T> {
     /// Check if an item is present in the set.
     ///
     /// There can be false positives, but no false negatives.
-    pub fn check(&self, item: &T) -> bool
-    where
-        T: Hash,
-    {
+    pub fn check(&self, item: &T) -> bool {
         let offsets = self.make_offsets(item);
         self.check_offsets(&offsets)
     }
@@ -179,20 +173,13 @@ impl<T: Hash> Bloom<T> {
     }
 
     /// Construct offsets for use later with `set_offsets`/`check_offsets`
-    pub fn make_offsets(&self, item: &T)
-    -> Vec<usize>
-    where
-        T: Hash
-    {
+    pub fn make_offsets(&self, item: &T) -> Vec<usize> {
         self.config.make_offsets(item)
     }
 
     /// Record the presence of an item in the set,
     /// and return the previous state of this item.
-    pub fn check_and_set(&mut self, item: &T) -> bool
-    where
-        T: Hash,
-    {
+    pub fn check_and_set(&mut self, item: &T) -> bool {
         let offsets = self.make_offsets(item);
         if self.check_offsets(&offsets) {
             true
@@ -241,11 +228,7 @@ impl<T: Hash> BloomHasher<T> {
         }
     }
 
-    pub fn make_offsets(&self, item: &T)
-    -> Vec<usize>
-    where
-        T: Hash
-    {
+    pub fn make_offsets(&self, item: &T) -> Vec<usize> {
         let mut hashes = [0u64, 0u64];
         let mut ret = Vec::with_capacity(self.k_num as usize);
         for k_i in 0..self.k_num {
@@ -256,10 +239,7 @@ impl<T: Hash> BloomHasher<T> {
         ret
     }
 
-    fn bloom_hash(&self, hashes: &mut [u64; 2], item: &T, k_i: u32) -> u64
-    where
-        T: Hash,
-    {
+    fn bloom_hash(&self, hashes: &mut [u64; 2], item: &T, k_i: u32) -> u64 {
         if k_i < 2 {
             let sip = &mut self.sips[k_i as usize].clone();
             item.hash(sip);

--- a/src/bloomfilter/lib.rs
+++ b/src/bloomfilter/lib.rs
@@ -19,142 +19,88 @@ extern crate siphasher;
 
 use bit_vec::BitVec;
 use siphasher::sip::SipHasher13;
+
 use std::cmp;
 use std::f64;
 use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
 
 #[cfg(test)]
 use rand::Rng;
 
 /// Bloom filter structure
-pub struct Bloom {
-    bitmap: BitVec,
+#[derive(Clone)]
+pub struct Bloom<T: Hash> {
+    state: BloomState,
+    config: BloomHasher<T>,
+
+    // We use T for type safety but we don't use T for anything else, so we need
+    // to convince the compiler that we use it
+    phantom: PhantomData<T>,
+}
+
+/// The current state of a Bloom filter
+#[derive(Clone)]
+pub struct BloomState {
+    pub(crate) bitmap: BitVec,
+}
+
+/// The configuration used to create a Bloom filter
+#[derive(Clone)]
+pub struct BloomHasher<T: Hash> {
     bitmap_bits: u64,
     k_num: u32,
     sips: [SipHasher13; 2],
+
+    // we only use T for type safety so we we don't use any methods of, but we
+    // need to convince the compiler that we use it
+    phantom: PhantomData<T>,
 }
 
-impl Bloom {
+impl<T: Hash> Bloom<T> {
     /// Create a new bloom filter structure.
-    /// bitmap_size is the size in bytes (not bits) that will be allocated in memory
-    /// items_count is an estimation of the maximum number of items to store.
-    pub fn new(bitmap_size: usize, items_count: usize) -> Bloom {
+    ///
+    /// * `bitmap_size` - the size in bytes (not bits) that will be allocated in memory
+    /// * `items_count` - an estimation of the maximum number of items to store.
+    pub fn new(bitmap_size: usize, items_count: usize) -> Self {
         assert!(bitmap_size > 0 && items_count > 0);
         let bitmap_bits = (bitmap_size as u64) * 8u64;
-        let k_num = Bloom::optimal_k_num(bitmap_bits, items_count);
+        let k_num = Self::optimal_k_num(bitmap_bits, items_count);
         let bitmap = BitVec::from_elem(bitmap_bits as usize, false);
-        let sips = [Bloom::sip_new(), Bloom::sip_new()];
-        Bloom {
-            bitmap: bitmap,
-            bitmap_bits: bitmap_bits,
-            k_num: k_num,
-            sips: sips,
-        }
+        let sips = [Self::sip_new(), Self::sip_new()];
+        let config = BloomHasher::new(bitmap_bits, k_num, sips);
+        let state = BloomState{bitmap};
+        Bloom {state, config, phantom: PhantomData}
     }
 
     /// Create a new bloom filter structure.
-    /// items_count is an estimation of the maximum number of items to store.
-    /// fp_p is the wanted rate of false positives, in ]0.0, 1.0[
-    pub fn new_for_fp_rate(items_count: usize, fp_p: f64) -> Bloom {
-        let bitmap_size = Bloom::compute_bitmap_size(items_count, fp_p);
+    ///
+    /// * `items_count` - an estimation of the maximum number of items to store.
+    /// * `fp_p` - the wanted rate of false positives, in ]0.0, 1.0[
+    pub fn new_for_fp_rate(items_count: usize, fp_p: f64) -> Self {
+        let bitmap_size = Self::compute_bitmap_size(items_count, fp_p);
         Bloom::new(bitmap_size, items_count)
     }
 
     /// Create a bloom filter structure with an existing state.
-    /// The state is assumed to be retrieved from an existing bloom filter.
+    ///
+    /// `state` is assumed to be retrieved from an existing bloom filter.
     pub fn from_existing(
         bitmap: &[u8],
         bitmap_bits: u64,
         k_num: u32,
         sip_keys: [(u64, u64); 2],
-    ) -> Bloom {
+    ) -> Self {
         let sips = [
             SipHasher13::new_with_keys(sip_keys[0].0, sip_keys[0].1),
             SipHasher13::new_with_keys(sip_keys[1].0, sip_keys[1].1),
         ];
+        let bitmap = BitVec::from_bytes(bitmap);
         Bloom {
-            bitmap: BitVec::from_bytes(bitmap),
-            bitmap_bits: bitmap_bits,
-            k_num: k_num,
-            sips: sips,
+            state: BloomState{bitmap},
+            config: BloomHasher::new(bitmap_bits, k_num, sips),
+            phantom: PhantomData,
         }
-    }
-
-    /// Compute a recommended bitmap size for items_count items
-    /// and a fp_p rate of false positives.
-    /// fp_p obviously has to be within the ]0.0, 1.0[ range.
-    pub fn compute_bitmap_size(items_count: usize, fp_p: f64) -> usize {
-        assert!(items_count > 0);
-        assert!(fp_p > 0.0 && fp_p < 1.0);
-        let log2 = f64::consts::LN_2;
-        let log2_2 = log2 * log2;
-        ((items_count as f64) * f64::ln(fp_p) / (-8.0 * log2_2)).ceil() as usize
-    }
-
-    /// Record the presence of an item.
-    pub fn set<T>(&mut self, item: T)
-    where
-        T: Hash,
-    {
-        let mut hashes = [0u64, 0u64];
-        for k_i in 0..self.k_num {
-            let bit_offset = (self.bloom_hash(&mut hashes, &item, k_i) % self.bitmap_bits) as usize;
-            self.bitmap.set(bit_offset, true);
-        }
-    }
-
-    /// Check if an item is present in the set.
-    /// There can be false positives, but no false negatives.
-    pub fn check<T>(&self, item: T) -> bool
-    where
-        T: Hash,
-    {
-        let mut hashes = [0u64, 0u64];
-        for k_i in 0..self.k_num {
-            let bit_offset = (self.bloom_hash(&mut hashes, &item, k_i) % self.bitmap_bits) as usize;
-            if self.bitmap.get(bit_offset).unwrap() == false {
-                return false;
-            }
-        }
-        true
-    }
-
-    /// Record the presence of an item in the set,
-    /// and return the previous state of this item.
-    pub fn check_and_set<T>(&mut self, item: T) -> bool
-    where
-        T: Hash,
-    {
-        let mut hashes = [0u64, 0u64];
-        let mut found = true;
-        for k_i in 0..self.k_num {
-            let bit_offset = (self.bloom_hash(&mut hashes, &item, k_i) % self.bitmap_bits) as usize;
-            if self.bitmap.get(bit_offset).unwrap() == false {
-                found = false;
-                self.bitmap.set(bit_offset, true);
-            }
-        }
-        found
-    }
-
-    /// Return the bitmap as a vector of bytes
-    pub fn bitmap(&self) -> Vec<u8> {
-        self.bitmap.to_bytes()
-    }
-
-    /// Return the number of bits in the filter
-    pub fn number_of_bits(&self) -> u64 {
-        self.bitmap_bits
-    }
-
-    /// Return the number of hash functions used for `check` and `set`
-    pub fn number_of_hash_functions(&self) -> u32 {
-        self.k_num
-    }
-
-    /// Return the keys used by the sip hasher
-    pub fn sip_keys(&self) -> [(u64, u64); 2] {
-        [self.sips[0].keys(), self.sips[1].keys()]
     }
 
     fn optimal_k_num(bitmap_bits: u64, items_count: usize) -> u32 {
@@ -164,7 +110,153 @@ impl Bloom {
         cmp::max(k_num, 1)
     }
 
-    fn bloom_hash<T>(&self, hashes: &mut [u64; 2], item: &T, k_i: u32) -> u64
+    fn sip_new() -> SipHasher13 {
+        let mut rng = rand::thread_rng();
+        SipHasher13::new_with_keys(
+            rand::Rand::rand(&mut rng),
+            rand::Rand::rand(&mut rng)
+        )
+    }
+
+    /// Get a reference to the configuration used to build this Bloom filter.
+    ///
+    /// This hasher can be used to calculate offsets to be used with this Bloom
+    /// filter later. This is mostly useful the actual hashing operation is very
+    /// expensive or is being done in another thread
+    pub fn get_hasher<'a>(&'a self) -> &'a BloomHasher<T> {
+        &self.config
+    }
+
+    /// Compute a recommended bitmap size for `items_count` items
+    /// and a `fp_p` rate of false positives.
+    ///
+    /// `fp_p` obviously has to be within the ]0.0, 1.0[ range.
+    pub fn compute_bitmap_size(items_count: usize, fp_p: f64) -> usize {
+        assert!(items_count > 0);
+        assert!(fp_p > 0.0 && fp_p < 1.0);
+        let log2 = f64::consts::LN_2;
+        let log2_2 = log2 * log2;
+        ((items_count as f64) * f64::ln(fp_p) / (-8.0 * log2_2)).ceil() as usize
+    }
+
+    /// Record the presence of an item.
+    pub fn set(&mut self, item: &T)
+    where
+        T: Hash,
+    {
+        let offsets = self.make_offsets(item);
+        self.set_offsets(&offsets);
+    }
+
+    /// Record the presence of an item (using pre-built offsets)
+    pub fn set_offsets(&mut self, offsets: &[usize]) {
+        for offset in offsets {
+            self.state.bitmap.set(*offset, true);
+        }
+    }
+
+    /// Check if an item is present in the set.
+    ///
+    /// There can be false positives, but no false negatives.
+    pub fn check(&self, item: &T) -> bool
+    where
+        T: Hash,
+    {
+        let offsets = self.make_offsets(item);
+        self.check_offsets(&offsets)
+    }
+
+    /// Check if an item is present in the set (using pre-built offsets).
+    ///
+    /// There can be false positives, but no false negatives.
+    pub fn check_offsets(&self, offsets: &[usize]) -> bool {
+        for offset in offsets {
+            if self.state.bitmap.get(*offset).unwrap() == false {
+                return false
+            }
+        }
+        true
+    }
+
+    /// Construct offsets for use later with `set_offsets`/`check_offsets`
+    pub fn make_offsets(&self, item: &T)
+    -> Vec<usize>
+    where
+        T: Hash
+    {
+        self.config.make_offsets(item)
+    }
+
+    /// Record the presence of an item in the set,
+    /// and return the previous state of this item.
+    pub fn check_and_set(&mut self, item: &T) -> bool
+    where
+        T: Hash,
+    {
+        let offsets = self.make_offsets(item);
+        if self.check_offsets(&offsets) {
+            true
+        } else {
+            self.set_offsets(&offsets);
+            false
+        }
+    }
+
+    /// Return the bitmap as a vector of bytes
+    pub fn bitmap(&self) -> Vec<u8> {
+        self.state.bitmap.to_bytes()
+    }
+
+    /// Return the bitmap as a read-only reference to the internal BitVec
+    pub fn bitmap_ref<'a>(&'a self) -> &'a BitVec {
+        &self.state.bitmap
+    }
+
+    /// Return the number of bits in the filter
+    pub fn number_of_bits(&self) -> u64 {
+        self.config.bitmap_bits
+    }
+
+    /// Return the number of hash functions used for `check` and `set`
+    pub fn number_of_hash_functions(&self) -> u32 {
+        self.config.k_num
+    }
+
+    /// Return the keys used by the sip hasher
+    pub fn sip_keys(&self) -> [(u64, u64); 2] {
+        self.config.sip_keys()
+    }
+
+    /// Clear all of the bits in the filter, removing all keys from the set
+    pub fn clear(&mut self) {
+        self.state.bitmap.clear()
+    }
+}
+
+impl<T: Hash> BloomHasher<T> {
+    fn new(bitmap_bits: u64, k_num: u32, sips: [SipHasher13;2]) -> Self {
+        BloomHasher{
+            bitmap_bits, k_num, sips,
+            phantom: PhantomData
+        }
+    }
+
+    pub fn make_offsets(&self, item: &T)
+    -> Vec<usize>
+    where
+        T: Hash
+    {
+        let mut hashes = [0u64, 0u64];
+        let mut ret = Vec::with_capacity(self.k_num as usize);
+        for k_i in 0..self.k_num {
+            let hashed = self.bloom_hash(&mut hashes, item, k_i);
+            let bit_offset = (hashed % self.bitmap_bits) as usize;
+            ret.push(bit_offset)
+        }
+        ret
+    }
+
+    fn bloom_hash(&self, hashes: &mut [u64; 2], item: &T, k_i: u32) -> u64
     where
         T: Hash,
     {
@@ -179,14 +271,8 @@ impl Bloom {
         }
     }
 
-    /// Clear all of the bits in the filter, removing all keys from the set
-    pub fn clear(&mut self) {
-        self.bitmap.clear()
-    }
-
-    fn sip_new() -> SipHasher13 {
-        let mut rng = rand::thread_rng();
-        SipHasher13::new_with_keys(rand::Rand::rand(&mut rng), rand::Rand::rand(&mut rng))
+    fn sip_keys(&self) -> [(u64, u64); 2] {
+        [self.sips[0].keys(), self.sips[1].keys()]
     }
 }
 
@@ -196,21 +282,21 @@ fn bloom_test_set() {
     let key: &Vec<u8> = &rand::thread_rng().gen_iter::<u8>().take(16).collect();
     assert!(bloom.check(key) == false);
     bloom.set(&key);
-    assert!(bloom.check(key.clone()) == true);
+    assert!(bloom.check(&key) == true);
 }
 
 #[test]
 fn bloom_test_check_and_set() {
     let mut bloom = Bloom::new(10, 80);
-    let key: &Vec<u8> = &rand::thread_rng().gen_iter::<u8>().take(16).collect();
-    assert!(bloom.check_and_set(key) == false);
-    assert!(bloom.check_and_set(key.clone()) == true);
+    let key: Vec<u8> = rand::thread_rng().gen_iter::<u8>().take(16).collect();
+    assert!(bloom.check_and_set(&key) == false);
+    assert!(bloom.check_and_set(&key) == true);
 }
 
 #[test]
 fn bloom_test_clear() {
     let mut bloom = Bloom::new(10, 80);
-    let key: &Vec<u8> = &rand::thread_rng().gen_iter::<u8>().take(16).collect();
+    let key: Vec<u8> = rand::thread_rng().gen_iter::<u8>().take(16).collect();
     bloom.set(&key);
     assert!(bloom.check(&key) == true);
     bloom.clear();
@@ -220,13 +306,37 @@ fn bloom_test_clear() {
 #[test]
 fn bloom_test_load() {
     let mut original = Bloom::new(10, 80);
-    let key: &Vec<u8> = &rand::thread_rng().gen_iter::<u8>().take(16).collect();
+    let key: Vec<u8> = rand::thread_rng().gen_iter::<u8>().take(16).collect();
     original.set(&key);
-    assert!(original.check(key.clone()) == true);
+    assert!(original.check(&key) == true);
 
     let cloned = Bloom::from_existing(&original.bitmap(),
                                       original.number_of_bits(),
                                       original.number_of_hash_functions(),
                                       original.sip_keys());
-    assert!(cloned.check(key.clone()) == true);
+    assert!(cloned.check(&key) == true);
+}
+
+#[test]
+fn bloom_hasher_check() {
+    let mut original = Bloom::new(10, 80);
+    let key: Vec<u8> = rand::thread_rng().gen_iter::<u8>().take(16).collect();
+    let hasher = original.get_hasher().clone();
+    let offsets = hasher.make_offsets(&key);
+
+    assert!(original.check_offsets(&offsets) == false);
+    original.set(&key);
+    assert!(original.check_offsets(&offsets) == true);
+}
+
+#[test]
+fn bloom_hasher_set() {
+    let mut original = Bloom::new(10, 80);
+    let key: Vec<u8> = rand::thread_rng().gen_iter::<u8>().take(16).collect();
+    let hasher = original.get_hasher().clone();
+    let offsets = hasher.make_offsets(&key);
+
+    assert!(original.check(&key) == false);
+    original.set_offsets(&offsets);
+    assert!(original.check(&key) == true);
 }


### PR DESCRIPTION
This commit got kind of out of hand and in https://github.com/jedisct1/rust-bloom-filter/issues/7 you specifically mentioned minimising invasiveness so I wanted to pause here to see which bits you're interested in before I chop it up into more acceptable commits. I'm aware that this commit can't be merged as-is but I wanted to get the back-and-forth started :)

This does:

* splits `Bloom`'s members into `BloomState` and `BloomHasher`, so that `BloomHasher` can be separately cloned to compute offsets in separate threads
* Splits `set` into `make_offsets`/`set_offsets` (and ditto for `get`) so that those offsets built-up elsewhere can be used. (I think `offsets` here is a dumb name and I've love a better one if you have one :) )
  - I believe this is the only place with a performance change: prior to this `get` was able to avoid computing all of the offsets if the item was found with an earlier one. Now it always computes them all. If you feel this is a problem it can be avoided with a tiny bit of code duplication
* `get`/`set` now take references instead of consuming their arguments.
  - This is an API change. I incremented the minor version for this but I expect it's probably better to increment the major version instead
* Makes `Bloom` into `Bloom<T>` so it's not possible to accidentally mix types between `get`/`set`. This came up for me when using it, finding that because a `T` and a `&T` do `Hash` differently, which makes sense. But it means that improperly adding/forgetting a `&` somewhere made my program incorrect (rather than simply not compile which I'd generally prefer).
  - This is a bigger API change :) It's is probably mostly source-compatible unless the code using it previously was incorrect
* Adds a method to get a reference to the raw BitVec. This came up for me in wanting to minimise the number of copies for very large filters when trying to write serialised filters to a file

I'm totally willing to drop any of those things and of course I'll rearrange the commits so that the history is more reasonable