### PR TITLE
Change the type signature of Bloom to Bloom<T>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bloomfilter"
-version = "0.0.12"
+version = "1.0.0"
 authors = ["Frank Denis <github@pureftpd.org>"]
 description = "Bloom filter implementation"
 license = "ISC"


### PR DESCRIPTION
Prior to this, Bloom didn't take a type argument. Instead, Bloom::get and
Bloom::set separately took their own type arguments. This made it possible to
accidentally store different types inside of the same Bloom. In particular, one
could mistakenly store a T and a &T (which may hash differently) which would
silently make the filter contain incorrect data.

I also took the API breakage opportunity to make Bloom::get and Bloom::set take
references instead of consuming their arguments

Because of the breaking API change, this increments the version from 0.0.12 ->
1.0.0

Split out to separate from https://github.com/jedisct1/rust-bloom-filter/pull/8