### PR TITLE
added serde derive, feature flag and test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,14 @@ name = "bloomfilter"
 path = "src/bloomfilter/lib.rs"
 
 [dependencies]
-bit-vec = "0.6.1"
+bit-vec = { version = "0.6.1", features = ["serde"] }
 rand = "0.7"
-siphasher = "0.3.1"
+siphasher = {version = "0.3.2", features = ["serde"] }
+serde = { version = "1.0.104", features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_json = "1.0"
+
+[features]
+default = ["std"]
+std = []

--- a/src/bloomfilter/lib.rs
+++ b/src/bloomfilter/lib.rs
@@ -27,7 +27,7 @@ use std::marker::PhantomData;
 use rand::Rng;
 
 /// Bloom filter structure
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bloom<T: ?Sized> {
     bitmap: BitVec,
@@ -262,5 +262,7 @@ fn bloom_test_serde() {
     let deserialized: Bloom<Vec<u8>> = serde_json::from_str(&serialized).unwrap();
 
     assert!(deserialized.check(&key) == true);
-    assert_eq!(original, deserialized);
+
+    // PartialEq or Eq not implemented yet for Bloom
+    // assert_eq!(original, deserialized);
 }

--- a/src/bloomfilter/lib.rs
+++ b/src/bloomfilter/lib.rs
@@ -6,6 +6,7 @@
 //! 2 hash functions, generated with SipHash-1-3 using randomized keys.
 //!
 
+#![forbid(unsafe_code)]
 #![crate_name = "bloomfilter"]
 #![crate_type = "rlib"]
 #![warn(non_camel_case_types, non_upper_case_globals, unused_qualifications)]
@@ -26,6 +27,8 @@ use std::marker::PhantomData;
 use rand::Rng;
 
 /// Bloom filter structure
+#[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bloom<T: ?Sized> {
     bitmap: BitVec,
     bitmap_bits: u64,
@@ -242,4 +245,22 @@ fn bloom_test_load() {
         original.sip_keys(),
     );
     assert!(cloned.check(&key) == true);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn bloom_test_serde() {
+    let mut rng = thread_rng();
+    let mut original = Bloom::new(10, 80);
+    let mut key = vec![0u8, 16];
+    rng.fill_bytes(&mut key);
+    original.set(&key);
+    assert!(original.check(&key) == true);
+
+    let serialized = serde_json::to_string(&original).unwrap();
+
+    let deserialized: Bloom<Vec<u8>> = serde_json::from_str(&serialized).unwrap();
+
+    assert!(deserialized.check(&key) == true);
+    assert_eq!(original, deserialized);
 }


### PR DESCRIPTION
Bloom filters can now be serialized to whatever has a serde implementation. 
A test to verify the serializing and deserializing process is also added but currently only executed if the feature flag for "serde" is set.
`Cargo.toml` now contains a not yet valid new minor version of siphash (https://github.com/jedisct1/rust-siphash/pull/12)
This might need tweaking if you want to increase the major number.

I did not add the feature to the default feature list. To use serde one has to specify `features = ["serde"]`. It might be better to include this in the default list... 

Finally, I added `#![forbid(unsafe_code)]` to the top of `lib.rs` as no unsafe code is needed here and it gives a fancy super secure symbol in `cargo-geiger` ;) 