### PR TITLE
multiplication in u128 before mod 0xffffffffffffffc5

### DIFF
--- a/src/bloomfilter/lib.rs
+++ b/src/bloomfilter/lib.rs
@@ -178,7 +178,8 @@ impl<T: ?Sized> Bloom<T> {
             hashes[k_i as usize] = hash;
             hash
         } else {
-            hashes[0].wrapping_add((k_i as u64).wrapping_mul(hashes[1]) % 0xffffffffffffffc5)
+            ((hashes[0] as u128) + ((k_i as u128) * (hashes[1] as u128)) % 0xffffffffffffffc5)
+                as u64
         }
     }
 


### PR DESCRIPTION
After you make wrapping_mul (=multiplication + mod 2**64) it does not make much sense to take mod 2**64-57 (in most cases the second will take no effect at all). As a result, for example, all entities have exactly k/2 odd and k/2 even coordinates. It damages guarantees a bit.