### PR TITLE
Move rand crate behind feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,13 @@ edition = "2018"
 
 [dependencies]
 bit-vec = "0.6.3"
-rand = "0.8.3"
+rand = { version = "0.8.3", optional = true }
 siphasher = "0.3.5"
 
+[dev-dependencies]
+rand = "0.8.3"
+
 [features]
-defaults = []
+defaults = ["random"]
+random = ["rand"]
 serde = ["siphasher/serde_std", "bit-vec/serde"]


### PR DESCRIPTION
This PR places the crate's requirement on the `rand` behind a feature gate, so that it can be supported on bare-metal embedded and WebAssembly platforms. (Random generation is of course enabled by default.)

To achieve this, it adds two functions to create SIP hashers with provided initial state, rather than randomly generating it.