### PR TITLE
[bitvec] change from bit-vec to bitvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/jedisct1/rust-bloom-filter"
 edition = "2018"
 
 [dependencies]
-bit-vec = "0.6.3"
-getrandom = { version = "0.2.3", optional = true }
-siphasher = "0.3.7"
+bitvec = "1.0.1"
+getrandom = { version = "0.2.8", optional = true }
+siphasher = "0.3.10"
 
 [features]
 default = ["random"]
 random = ["getrandom"]
-serde = ["siphasher/serde_std", "bit-vec/serde"]
+serde = ["siphasher/serde_std", "bitvec/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-[project]
+[package]
 name = "bloomfilter"
 version = "1.0.9"
 authors = ["Frank Denis <github@pureftpd.org>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 #![warn(non_camel_case_types, non_upper_case_globals, unused_qualifications)]
 #![allow(clippy::unreadable_literal, clippy::bool_comparison)]
 
-use bit_vec::BitVec;
+use bitvec::prelude::BitVec;
 #[cfg(feature = "random")]
 use getrandom::getrandom;
 use siphasher::sip::SipHasher13;
@@ -22,12 +22,12 @@ use std::marker::PhantomData;
 use siphasher::reexports::serde;
 
 pub mod reexports {
+    pub use bitvec;
     #[cfg(feature = "random")]
-    pub use ::getrandom;
-    pub use bit_vec;
+    pub use getrandom;
+    pub use siphasher;
     #[cfg(feature = "serde")]
     pub use siphasher::reexports::serde;
-    pub use siphasher;
 }
 
 /// Bloom filter structure
@@ -35,7 +35,7 @@ pub mod reexports {
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[derive(Clone, Debug)]
 pub struct Bloom<T: ?Sized> {
-    bit_vec: BitVec,
+    bit_vec: BitVec<u8>,
     bitmap_bits: u64,
     k_num: u32,
     sips: [SipHasher13; 2],
@@ -52,7 +52,8 @@ impl<T: ?Sized> Bloom<T> {
         assert!(bitmap_size > 0 && items_count > 0);
         let bitmap_bits = (bitmap_size as u64) * 8u64;
         let k_num = Self::optimal_k_num(bitmap_bits, items_count);
-        let bitmap = BitVec::from_elem(bitmap_bits as usize, false);
+        let mut bitmap = BitVec::new();
+        bitmap.resize(bitmap_bits as usize, false);
         let mut k1 = [0u8; 16];
         let mut k2 = [0u8; 16];
         k1.copy_from_slice(&seed[0..16]);
@@ -97,7 +98,7 @@ impl<T: ?Sized> Bloom<T> {
     /// Create a bloom filter structure from a previous state given as a `ByteVec` structure.
     /// The state is assumed to be retrieved from an existing bloom filter.
     pub fn from_bit_vec(
-        bit_vec: BitVec,
+        bit_vec: BitVec<u8>,
         bitmap_bits: u64,
         k_num: u32,
         sip_keys: [(u64, u64); 2],
@@ -123,7 +124,7 @@ impl<T: ?Sized> Bloom<T> {
         k_num: u32,
         sip_keys: [(u64, u64); 2],
     ) -> Self {
-        Self::from_bit_vec(BitVec::from_bytes(bytes), bitmap_bits, k_num, sip_keys)
+        Self::from_bit_vec(BitVec::from_slice(bytes), bitmap_bits, k_num, sip_keys)
     }
 
     /// Compute a recommended bitmap size for items_count items
@@ -158,8 +159,13 @@ impl<T: ?Sized> Bloom<T> {
         let mut hashes = [0u64, 0u64];
         for k_i in 0..self.k_num {
             let bit_offset = (self.bloom_hash(&mut hashes, item, k_i) % self.bitmap_bits) as usize;
-            if self.bit_vec.get(bit_offset).unwrap() == false {
-                return false;
+            match self.bit_vec.get(bit_offset) {
+                Some(b) => {
+                    if !b {
+                        return false;
+                    }
+                }
+                None => return false,
             }
         }
         true
@@ -185,11 +191,11 @@ impl<T: ?Sized> Bloom<T> {
 
     /// Return the bitmap as a vector of bytes
     pub fn bitmap(&self) -> Vec<u8> {
-        self.bit_vec.to_bytes()
+        self.bit_vec.clone().into_vec()
     }
 
     /// Return the bitmap as a "BitVec" structure
-    pub fn bit_vec(&self) -> &BitVec {
+    pub fn bit_vec(&self) -> &BitVec<u8> {
         &self.bit_vec
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,13 +159,8 @@ impl<T: ?Sized> Bloom<T> {
         let mut hashes = [0u64, 0u64];
         for k_i in 0..self.k_num {
             let bit_offset = (self.bloom_hash(&mut hashes, item, k_i) % self.bitmap_bits) as usize;
-            match self.bit_vec.get(bit_offset) {
-                Some(b) => {
-                    if !b {
-                        return false;
-                    }
-                }
-                None => return false,
+            if self.bit_vec.get(bit_offset).unwrap() == false {
+                return false;
             }
         }
         true
@@ -240,7 +235,7 @@ impl<T: ?Sized> Bloom<T> {
 
     /// Clear all of the bits in the filter, removing all keys from the set
     pub fn clear(&mut self) {
-        self.bit_vec.clear()
+        self.bit_vec.fill(false)
     }
 
     #[inline]


### PR DESCRIPTION
This is basically a dependency change, going from https://crates.io/crates/bit-vec to https://crates.io/crates/bitvec

The change was quite straightforward, a few things still:

* since some of your funcs export as `Vec<u8>` I had to use `BitVec<u8>` instead of the default `BitVec` which is a `BitVec<usize>`. I did not investigate to see if that would speed up things, but maybe it does.
* I did some basic perf testing, introducing benches. There are 2 branches, one [with my patch here](https://github.com/ufoot/rust-bloom-filter/pull/1) and one [without the patch there](https://github.com/ufoot/rust-bloom-filter/pull/2) (the current implementation). Both yield exactly the same results. The difference is unnoticeable.
* the reason I would appreciate this change is that this bitvec library has [count_ones](https://docs.rs/bitvec/latest/bitvec/vec/struct.BitVec.html#method.count_ones) which is interesting to get a feeling of whether the Bloom filter is full, or not.
* there is one change that I found a bit strange, the `clear()` function seems to have different semantics in both libraries, looks like [the one in the new library](https://docs.rs/bitvec/latest/bitvec/vec/struct.BitVec.html#method.clear) clears the data but keeps the capacity. I fail to see how that is practically possible on bits but it looks like it works anyway.

Happy to have your feedback on this, I was about to re-implement some Bloom filter with this bitvec, and found adapting your concise (and great!) library was really good enough. 