### PR TITLE
Fix `cargo` warning on project vs package key name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-[project]
+[package]
 name = "bloomfilter"
 version = "1.0.9"
 authors = ["Frank Denis <github@pureftpd.org>"]


### PR DESCRIPTION
The `cargo` warning is pretty self-explanatory:

warning: manifest at `/.../rust-bloom-filter` contains `[project]` instead of `[package]`, this could become a hard error in the future