### PR TITLE
Support `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,13 @@ keywords = ["bloom", "filter"]
 readme = "README.md"
 
 [dependencies]
-bit-vec = "0.6.3"
+bit-vec = { version = "0.6.3", default-features = false }
 getrandom = { version = "0.2.10", optional = true }
-siphasher = "1.0.0"
+libm = "0.2.7"
+siphasher = { version = "1.0.0", default-features = false }
 
 [features]
-default = ["random"]
+default = ["random", "std"]
 random = ["getrandom"]
-serde = ["siphasher/serde_std", "bit-vec/serde"]
+serde = ["std", "siphasher/serde_std", "bit-vec/serde"]
+std = ["bit-vec/std", "siphasher/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,15 @@
 //! This is a simple but fast Bloom filter implementation, that requires only
 //! 2 hash functions, generated with SipHash-1-3 using randomized keys.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(non_camel_case_types, non_upper_case_globals, unused_qualifications)]
 #![allow(clippy::unreadable_literal, clippy::bool_comparison)]
 
-use std::cmp;
-use std::convert::TryFrom;
-use std::f64;
-use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
+use core::cmp;
+use core::convert::TryFrom;
+use core::f64;
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
 
 use bit_vec::BitVec;
 #[cfg(feature = "random")]
@@ -142,7 +143,7 @@ impl<T: ?Sized> Bloom<T> {
         assert!(fp_p > 0.0 && fp_p < 1.0);
         let log2 = f64::consts::LN_2;
         let log2_2 = log2 * log2;
-        ((items_count as f64) * f64::ln(fp_p) / (-8.0 * log2_2)).ceil() as usize
+        libm::ceil((items_count as f64) * libm::log(fp_p) / (-8.0 * log2_2)) as usize
     }
 
     /// Record the presence of an item.
@@ -192,6 +193,7 @@ impl<T: ?Sized> Bloom<T> {
     }
 
     /// Return the bitmap as a vector of bytes
+    #[cfg(feature = "std")]
     pub fn bitmap(&self) -> Vec<u8> {
         self.bit_vec.to_bytes()
     }
@@ -220,7 +222,7 @@ impl<T: ?Sized> Bloom<T> {
     fn optimal_k_num(bitmap_bits: u64, items_count: usize) -> u32 {
         let m = bitmap_bits as f64;
         let n = items_count as f64;
-        let k_num = (m / n * f64::ln(2.0f64)).ceil() as u32;
+        let k_num = libm::ceil(m / n * libm::log(2.0f64)) as u32;
         cmp::max(k_num, 1)
     }
 

--- a/tests/bloom.rs
+++ b/tests/bloom.rs
@@ -1,4 +1,6 @@
-use bloomfilter::{reexports::getrandom::getrandom, Bloom};
+use bloomfilter::Bloom;
+#[cfg(feature = "random")]
+use bloomfilter::reexports::getrandom::getrandom;
 
 #[test]
 #[cfg(feature = "random")]
@@ -34,7 +36,7 @@ fn bloom_test_clear() {
 }
 
 #[test]
-#[cfg(feature = "random")]
+#[cfg(all(feature = "random", feature = "std"))]
 fn bloom_test_load() {
     let mut original = Bloom::new(10, 80);
     let mut k = vec![0u8, 16];


### PR DESCRIPTION
Surprisingly, it's extremely difficult to find usable `no_std` implementations of approximate-membership structures on https://crates.io.

I've added an on-by-default `std` feature; when disabled this crate will support `no_std`.

Note that this adds the `libm` dependency, which is the [recommended](https://github.com/rust-lang/compiler-builtins/pull/248#issuecomment-412663267) approach for using methods like `std::primitive::f64::{ceil, ln}` in `no_std` contexts.