### PR TITLE
Number of hash functions (k) should be floored, not ceiled

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,82 @@
+#![feature(test)]
+
+extern crate test;
+
+use bloomfilter::Bloom;
+
+/* Set benchmarks */
+
+fn inner_insert_bench(b: &mut test::Bencher, bitmap_size: usize, items_count: usize) {
+    let mut bf: Bloom<usize> = Bloom::new(bitmap_size / 8, items_count);
+    let mut index = items_count;
+    b.iter(|| {
+        index += 1;
+        test::black_box(bf.set(&index));
+    });
+}
+
+#[bench]
+#[inline(always)]
+fn bench_insert_100(b: &mut test::Bencher) {
+    inner_insert_bench(b, 1000, 100);
+}
+
+
+#[bench]
+#[inline(always)]
+fn bench_insert_1000(b: &mut test::Bencher) {
+    inner_insert_bench(b, 10000, 1000);
+}
+
+#[bench]
+#[inline(always)]
+fn bench_insert_m_1(b: &mut test::Bencher) {
+    inner_insert_bench(b, 10_000_000, 1_000_000);
+}
+
+#[bench]
+#[inline(always)]
+fn bench_insert_m_10(b: &mut test::Bencher) {
+    inner_insert_bench(b, 100_000_000, 10_000_000);
+}
+
+/* Get benchmarks */
+
+fn inner_get_bench(b: &mut test::Bencher, bitmap_size: usize, items_count: usize) {
+    let mut bf: Bloom<usize> = Bloom::new(bitmap_size / 8, items_count);
+    for index in 0..items_count {
+        bf.set(&index);
+    }
+    let mut index = items_count;
+    b.iter(|| {
+        index += 1;
+        test::black_box(bf.check(&index));
+    });
+}
+
+
+#[bench]
+#[inline(always)]
+fn bench_get_100(b: &mut test::Bencher) {
+    inner_get_bench(b, 1000, 100);
+}
+
+
+#[bench]
+#[inline(always)]
+fn bench_get_1000(b: &mut test::Bencher) {
+    inner_get_bench(b, 10000, 1000);
+}
+
+
+#[bench]
+#[inline(always)]
+fn bench_get_m_1(b: &mut test::Bencher) {
+    inner_get_bench(b, 10_000_000, 1_000_000);
+}
+
+#[bench]
+#[inline(always)]
+fn bench_get_m_10(b: &mut test::Bencher) {
+    inner_get_bench(b, 100_000_000, 10_000_000);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use std::convert::TryFrom;
 use std::f64;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
+use std::cmp::max;
 
 use bit_vec::BitVec;
 #[cfg(feature = "random")]
@@ -220,7 +221,7 @@ impl<T: ?Sized> Bloom<T> {
     fn optimal_k_num(bitmap_bits: u64, items_count: usize) -> u32 {
         let m = bitmap_bits as f64;
         let n = items_count as f64;
-        let k_num = (m / n * f64::ln(2.0f64)).ceil() as u32;
+        let k_num = max((m / n * f64::ln(2.0f64)).floor() as u32, 1);
         cmp::max(k_num, 1)
     }
 

--- a/tests/bloom.rs
+++ b/tests/bloom.rs
@@ -50,3 +50,24 @@ fn bloom_test_load() {
     );
     assert!(cloned.check(&k));
 }
+
+/// Test the false positive rate of the bloom filter
+/// to ensure that using floor doesn't affect false positive rate
+/// in a significant way
+#[test]
+fn test_false_positive_rate() {
+    let capacities = [100, 1000, 10000, 100000, 1000000];
+    for capacity in capacities.iter() {
+        let mut bf: Bloom<usize> = Bloom::new(*capacity * 10 / 8, *capacity);
+        for index in 0..*capacity {
+            bf.set(&index);
+        }
+        let mut false_positives_count = 0.0;
+        for index in *capacity..11 * *capacity {
+            if bf.check(&index) {
+                false_positives_count += 1.0;
+            }
+        }
+        println!("False positive rate for capacity {}: {}", *capacity, false_positives_count / (10.0 * *capacity as f64));
+    }
+}


### PR DESCRIPTION
Historically, when calculating the number of hash functions (k) for Bloom filters, developers have commonly opted to use ceil() on the resulting float value. However, this approach is suboptimal. Instead, calling floor() on the result offers clear advantages over ceiling.

Flooring the number of hash functions does not meaningfully degrade the false-positive rate, as reducing by just one function still maintains a similar error probability. The risk of degradation only becomes a concern when additional hash functions are removed. However, by using floor() instead of ceil(), benchmarks demonstrate a notable 10% improvement in processing time. This improvement stems from the reduced number of hash functions, which decreases the filter's fill rate while keeping the same total bit count. As a result, the computational efficiency is enhanced without significantly compromising accuracy.

Moreover, having fewer hash functions means that, for elements that are 'probably in the set,' fewer bits need to be checked. For elements that are 'definitely not in the set,' each hash function has a higher chance of failing earlier due to the lower fill rate, further boosting overall efficiency.

```rust
With ceil()
test bench_get_100     ... bench:          62.71 ns/iter (+/- 0.60)
test bench_get_1000    ... bench:          62.35 ns/iter (+/- 0.63)
test bench_get_m_1     ... bench:          79.28 ns/iter (+/- 2.05)
test bench_get_m_10    ... bench:         101.78 ns/iter (+/- 10.46)
test bench_insert_100  ... bench:         119.64 ns/iter (+/- 3.92)
test bench_insert_1000 ... bench:         119.94 ns/iter (+/- 3.78)
test bench_insert_m_1  ... bench:         127.84 ns/iter (+/- 2.51)
test bench_insert_m_10 ... bench:         183.98 ns/iter (+/- 33.69)
```
to
```rust
With floor()
test bench_get_100     ... bench:          55.19 ns/iter (+/- 0.90)
test bench_get_1000    ... bench:          57.16 ns/iter (+/- 0.49)
test bench_get_m_1     ... bench:          71.36 ns/iter (+/- 0.70)
test bench_get_m_10    ... bench:          94.81 ns/iter (+/- 17.49)
test bench_insert_100  ... bench:         105.73 ns/iter (+/- 7.65)
test bench_insert_1000 ... bench:         105.82 ns/iter (+/- 3.88)
test bench_insert_m_1  ... bench:         115.46 ns/iter (+/- 3.02)
test bench_insert_m_10 ... bench:         162.82 ns/iter (+/- 18.40)
```