### PR TITLE
Updating seed() to return the key from sip 1 as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ impl<T: ?Sized> Bloom<T> {
     pub fn seed(&self) -> [u8; 32] {
         let mut seed = [0u8; 32];
         seed[0..16].copy_from_slice(&self.sips[0].key());
-        seed[16..32].copy_from_slice(&self.sips[0].key());
+        seed[16..32].copy_from_slice(&self.sips[1].key());
         seed
     }
 


### PR DESCRIPTION
There's an issue with correctness when using version 3.0.0 of the SDK. It's only using the first sip to return the seed but we also need the seed from the second sip as well.