### PR TITLE
Floor your bloom

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ impl<T: ?Sized> Bloom<T> {
     fn optimal_k_num(bitmap_bits: u64, items_count: usize) -> u32 {
         let m = bitmap_bits as f64;
         let n = items_count as f64;
-        let k_num = (m / n * f64::ln(2.0f64)).round() as u32;
+        let k_num = (m / n * f64::ln(2.0f64)).floor() as u32;
         cmp::max(k_num, 1)
     }
 


### PR DESCRIPTION
Always floor your Bloom filters!
The error rate difference is negligible, but this change removes one bitmap access. While small filters have minimal performance gains, large filters benefit by eliminating one memory dereference.

Benchmark results can be found [here](https://github.com/jedisct1/rust-bloom-filter/pull/45).